### PR TITLE
Update feature gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 *.synctex.gz
 *.bak
+
+*.csv

--- a/src/algorithms/bron_kerbosh.rs
+++ b/src/algorithms/bron_kerbosh.rs
@@ -98,7 +98,8 @@ fn bron_kerbosh_aux<F>(
     // modified p (p \ neighbourhood(pivot)), modified x
     let (mut ip, mut mp, mut mx) = (p.clone(), p.clone(), x.clone());
     let pivot = find_pivot(&p, &x, neighbourhoods);
-    ip.drain_filter(|e| neighbourhoods[pivot].contains(e));
+    ip.extract_if(|e| neighbourhoods[pivot].contains(e))
+        .collect::<Vec<usize>>();
 
     // while !mp.is_empty() {
     while !ip.is_empty() {
@@ -124,7 +125,8 @@ fn bron_kerbosh_aux<F>(
         // p \ { v }, x U { v }
         mp.remove(mp.iter().position(|x| *x == v).unwrap());
         ip = mp.clone();
-        ip.drain_filter(|e| neighbourhoods[pivot].contains(e));
+        ip.extract_if(|e| neighbourhoods[pivot].contains(e))
+            .collect::<Vec<usize>>();
         mx.push(v);
     }
 }
@@ -136,7 +138,8 @@ fn find_pivot(p: &[usize], x: &[usize], neighbourhoods: &[Vec<usize>]) -> usize 
     *px.iter()
         .min_by_key(|&e| {
             let mut pp = p.to_vec();
-            pp.drain_filter(|ee| neighbourhoods[*e].contains(ee));
+            pp.extract_if(|ee| neighbourhoods[*e].contains(ee))
+                .collect::<Vec<usize>>();
             pp.len()
         })
         .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 #![feature(int_roundings)]
 #![feature(iter_collect_into)]
-#![feature(drain_filter)]
-#![feature(option_result_contains)]
-#![feature(hash_drain_filter)]
+#![feature(extract_if)]
+#![feature(hash_extract_if)]
 
 pub mod aapp;
 pub mod algorithms;


### PR DESCRIPTION
The original code was not building for me locally, with the following compiler errors:
```
error[E0635]: unknown feature `hash_drain_filter`
 --> src/lib.rs:5:12
  |
5 | #![feature(hash_drain_filter)]
  |            ^^^^^^^^^^^^^^^^^

error[E0635]: unknown feature `option_result_contains`
 --> src/lib.rs:4:12
  |
4 | #![feature(option_result_contains)]
  |            ^^^^^^^^^^^^^^^^^^^^^^

error[E0635]: unknown feature `drain_filter`
 --> src/lib.rs:3:12
  |
3 | #![feature(drain_filter)]
  |            ^^^^^^^^^^^^

```
1. Based on [this](https://github.com/rust-lang/rust/issues/43244) and [this](https://github.com/rust-lang/rust/issues/59618), `drain_filter` has been renamed to `extract_if` and `hash_drain_filter` to `hash_extract_if`.  Therefore I've substituted the `drain_filter` calls with equivalent `extract_if` calls.
2. Based on [this](https://github.com/readysettech/readyset/commit/d33e7641215ed7b53bf99bc6384029a577dcd12d), the `option_result_contains` has been removed, as far as I can see there are no substitues. The code builds without this gate so I've removed it, but I'm not completely sure if that's the correct thing to do.